### PR TITLE
Disable bluebird warnings in tests

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -45,7 +45,11 @@ function makePromiseCompliant(module,promise,resolve) {
     return p ;
 }
 
-try { providers.push({name:'bluebird',p:require('bluebird')}) } catch (ex) { }
+try {
+    var bluebird = require('bluebird');
+    bluebird.config({ warnings: false });
+    providers.push({name:'bluebird',p:bluebird});
+} catch (ex) { }
 try { providers.push({name:'rsvp',p:require('rsvp').Promise}) } catch (ex) { }
 try { providers.push({name:'when',p:makePromiseCompliant(require('when'),'promise','resolve')}) } catch (ex) { }
 


### PR DESCRIPTION
Bluebird shows lots of warnings about promises not returned from functions where they are created in transpiled functions during the tests, that is normal there.
This config removes them.