### PR TITLE
async map in browser with require('nodent/map') instead of having to invoke nodent

### DIFF
--- a/lib/isThenable.js
+++ b/lib/isThenable.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function isThenable(obj) {
+	return (obj instanceof Object) && ('then' in obj) && typeof obj.then==="function";
+}
+
+module.exports = isThenable;

--- a/lib/thenable.js
+++ b/lib/thenable.js
@@ -1,0 +1,10 @@
+'use strict';
+
+function Thenable(thenable) {
+	return thenable.then = thenable ;
+};
+Thenable.resolve = function(v){
+	return ((v instanceof Object) && ('then' in v) && typeof v.then==="function")?v:{then:function(resolve){return resolve(v)}};
+};
+
+module.exports = Thenable;

--- a/map.js
+++ b/map.js
@@ -1,0 +1,6 @@
+"use strict";
+
+var Thenable = require('./lib/thenable');
+var isThenable = require('./lib/isThenable');
+
+module.exports = require('./covers/map')({Thenable: Thenable, isThenable: isThenable});

--- a/nodent.js
+++ b/nodent.js
@@ -12,6 +12,8 @@ var fs = require('fs') ;
 var outputCode = require('./lib/output') ;
 var parser = require('./lib/parser') ;
 var treeSurgeon = require('./lib/arboriculture') ;
+var Thenable = require('./lib/thenable') ;
+var isThenable = require('./lib/isThenable') ;
 
 // Config options used to control the run-time behaviour of the compiler
 var config = {
@@ -473,17 +475,6 @@ function $asyncspawn(promiseProvider,self) {
         }
         step(gen.next);
     });
-}
-
-function Thenable(thenable) {
-	return thenable.then = thenable ;
-};
-Thenable.resolve = function(v){
-	return ((v instanceof Object) && ('then' in v) && typeof v.then==="function")?v:{then:function(resolve){return resolve(v)}};
-};
-
-function isThenable(obj) {
-	return (obj instanceof Object) && ('then' in obj) && typeof obj.then==="function";
 }
 
 /* NodentCompiler prototypes, that refer to 'this' */


### PR DESCRIPTION
I could not manage require('nodent')().require('map') to work in the browser,
this way we just require('nodent/map') which won't pull the nodent dependencies like acorn into the bundle.