### PR TITLE
Fix try when not in a block, and throw/catch/finally logic (without an await) in an async function

### DIFF
--- a/lib/arboriculture.js
+++ b/lib/arboriculture.js
@@ -4,7 +4,7 @@
 var parser = require('./parser');
 var outputCode = require('./output');
 /** Helpers **/
-global.printNode = function printNode(n) {
+/*global.printNode =*/ function printNode(n) {
     if (!n) return '' ;
     if (Array.isArray(n))
         return n.map(printNode).join("|\n");
@@ -521,6 +521,7 @@ function asynchronize(pr, __sourceMapping, opts, logger) {
             });
         }
         var lambdaNesting = 0;
+        var tryNesting = 0 ;
         return parser.treeWalker(n, function (node, descend, path) {
             if (node.type === 'ReturnStatement' && !node.$mapped) {
                 if (lambdaNesting > 0) {
@@ -561,14 +562,23 @@ function asynchronize(pr, __sourceMapping, opts, logger) {
                     }
                     delete node.async;
                 }
-                node.type = 'ReturnStatement';
-                node.$mapped = true;
-                node.argument = {
-                    type: 'CallExpression',
-                    callee: getExit(path, [opts]).$error,
-                    arguments: [node.argument]
-                };
+                if (tryNesting) {
+                    descend() ;
+                } else {
+                  node.type = 'ReturnStatement';
+                  node.$mapped = true;
+                  node.argument = {
+                      type: 'CallExpression',
+                      callee: getExit(path, [opts]).$error,
+                      arguments: [node.argument]
+                  };
+                }
                 return;
+            } else if (node.type === 'TryStatement') {
+              tryNesting++;
+              descend(node);
+              tryNesting--;
+              return;
             } else if (examine(node).isFunction) {
                 lambdaNesting++;
                 descend(node);
@@ -764,8 +774,6 @@ function asynchronize(pr, __sourceMapping, opts, logger) {
                     type:'BlockStatement',
                     body:[node]
                   } ;
-//                  descend() ;
-//                  return ;
                 }
                 // Every try-catch needs a name, so asyncDefine/asyncAwait knows who's handling errors
                 node.$seh = generateSymbol("Try") + "_";
@@ -852,13 +860,6 @@ function asynchronize(pr, __sourceMapping, opts, logger) {
                     continuation = returnThisCall(deferredFinally(node));
                 }
             } else {
-//                afterTry = [] ;
-//                continuation = returnThisCall(deferredFinally(node));
-//                  ref.replace({
-//                    type:'BlockStatement',
-//                    body:[node]
-//                  }) ;
-//                  return ;
                 throw new Error(pr.filename + " - malformed try/catch blocks");
             }
             node.$mapped = true;

--- a/lib/arboriculture.js
+++ b/lib/arboriculture.js
@@ -4,7 +4,7 @@
 var parser = require('./parser');
 var outputCode = require('./output');
 /** Helpers **/
-function printNode(n) {
+global.printNode = function printNode(n) {
     if (!n) return '' ;
     if (Array.isArray(n))
         return n.map(printNode).join("|\n");
@@ -248,7 +248,7 @@ function asynchronize(pr, __sourceMapping, opts, logger) {
             left.type = 'ArrowFunctionExpression' ;
             return left ;
         }
-    
+
         if (opts.noRuntime) {
             if (arg) {
                 if (examine(arg).isLiteral) {
@@ -758,7 +758,15 @@ function asynchronize(pr, __sourceMapping, opts, logger) {
     /* Give unique names to TryCatch blocks */
     function labelTryCatch(ast,engineMode) {
         parser.treeWalker(ast, function (node, descend, path) {
-            if (node.type === 'TryStatement') {
+            if (node.type === 'TryStatement' && !node.$seh) {
+                if (!examine(path[0].parent).isBlockStatement) {
+                  path[0].parent[path[0].field] = {
+                    type:'BlockStatement',
+                    body:[node]
+                  } ;
+//                  descend() ;
+//                  return ;
+                }
                 // Every try-catch needs a name, so asyncDefine/asyncAwait knows who's handling errors
                 node.$seh = generateSymbol("Try") + "_";
                 node.$containedAwait = !!containsAwait(node);
@@ -844,6 +852,13 @@ function asynchronize(pr, __sourceMapping, opts, logger) {
                     continuation = returnThisCall(deferredFinally(node));
                 }
             } else {
+//                afterTry = [] ;
+//                continuation = returnThisCall(deferredFinally(node));
+//                  ref.replace({
+//                    type:'BlockStatement',
+//                    body:[node]
+//                  }) ;
+//                  return ;
                 throw new Error(pr.filename + " - malformed try/catch blocks");
             }
             node.$mapped = true;
@@ -874,7 +889,7 @@ function asynchronize(pr, __sourceMapping, opts, logger) {
                     "       {$:body}                                           "+
                     "       return $exit && ($exit.call(this, $value));        "+
                     "   })",finalParams).expr ;
-                
+
                 var finalizer = {
                     type: 'VariableDeclaration',
                     kind: 'var',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodent",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "description": "NoDent - Asynchronous Javascript language extensions",
   "main": "nodent.js",
   "scripts": {

--- a/tests/semantics/dual-nonblock-try.js
+++ b/tests/semantics/dual-nonblock-try.js
@@ -1,0 +1,45 @@
+'use nodent';
+async function nop(x) {
+    return x;
+}
+
+async function _un(a, b, c) {
+    try {
+        await nop();
+        if (b)
+            throw b;
+        return c;
+    } catch (ex) {
+        return ex;
+    }
+}
+
+async function _if(a, b, c) {
+    if (a)
+        try {
+        await nop();
+        if (b)
+            throw b;
+        return c;
+    } catch (ex) {
+        return ex;
+    }
+    return "."
+}
+
+async function _label(a, b, c) {
+    a:try {
+        await nop();
+        if (b)
+            throw b;
+        return c;
+    } catch (ex) {
+        return ex;
+    }
+}
+
+var s = "";
+for (var i = 0;i < 8; i++) {
+    s = s + await _un(i & 1, i & 2, i & 4)+ await _if(i & 1, i & 2, i & 4) + await _label(i & 1, i & 2, i & 4) + ", ";
+}
+return s ;

--- a/tests/semantics/dual-try-noawait.js
+++ b/tests/semantics/dual-try-noawait.js
@@ -22,6 +22,14 @@ async function fn2() {
     }
 }
 
+async function fn3() {
+    try {
+        throw '1';
+    } catch (ex) {
+        return '2';
+    }
+}
+
 async function fn(a) {
     try {
         if (a&1)
@@ -42,4 +50,4 @@ async function fn(a) {
 var s = "" ;
 for (var i=0; i<8; i++)
     s += await fn(i) ;
-return s+await fn1()+":"+await fn2();
+return s+await fn1()+":"+await fn2()+":"+await fn3();


### PR DESCRIPTION
Fix case where try/catch is not contained in a block (e.g, case, conditional or label)
Fix case where throw is incorrectly mapped inside a sync try to an exit, rather than the matching catch [NB: this mimics V8's _incorrect_ behaviour. After the fix it meets the specification and also Babel's implementation]